### PR TITLE
Add support for --token-usage flag, issue #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ _main.py [OPTIONS] GITHUB_REPOSITORY_URL COMMAND [ARGS]..._
 | `--temperature` | `-t`     | Option | Set the temperature for the model's output randomness | `0.5`   |
 | `--output`      | `-o`     | PATH   | Path to the output file                               | None    |
 | `--help`        |          | Flag   | Show this message and exit                            | `N/A`   |
+| `--token-usage` |          | Flag   | Displays token usage to the user via `stderr`         | `N/A`   |
 
 ## More about `github-echo`
 

--- a/_main.py
+++ b/_main.py
@@ -47,6 +47,9 @@ def github_repo_insights(
     output_file: Annotated[
         Optional[Path], typer.Option("--output", "-o", help="Path to the output file")
     ] = None,
+    token_usage: Annotated[
+        bool, typer.Option("--token-usage", help="Flag for printing token usage")
+    ] = False,
 ):
     """
     Main function to analyze a GitHub repository and optionally output the results to a file.
@@ -61,6 +64,7 @@ def github_repo_insights(
             github_repository_url=github_repository_url,
             output_file=output_file,
             model_temperature=model_temperature,
+            token_usage=token_usage
         )
     except Exception as e:
         err_console.print("\n[bold red]🚨 Something went wrong![/bold red]\n")

--- a/application/core/gemini_model.py
+++ b/application/core/gemini_model.py
@@ -4,12 +4,10 @@ from typing import Any, Dict
 import google.generativeai as genai
 
 from _config import GOOGLE_GEMINI_API_KEY
-from application.utils.gemini_config import (
-    GEMINI_MODEL,
-    GEMINI_SYSTEM_INSTRUCTION,
-    generate_gemini_prompt,
-    get_gemini_generation_config,
-)
+from application.utils.gemini_config import (GEMINI_MODEL,
+                                             GEMINI_SYSTEM_INSTRUCTION,
+                                             generate_gemini_prompt,
+                                             get_gemini_generation_config)
 from application.utils.parser import json_to_markdown
 
 # Configure the Gemini GenAI API in order to make requests to it
@@ -25,7 +23,7 @@ model = genai.GenerativeModel(
 )
 
 
-def get_gemini_summary(github_data: Dict[str, Any], model_temperature: float) -> str:
+def get_gemini_summary(github_data: Dict[str, Any], model_temperature: float) -> Dict[str, str]:
     """
     Generates a summary of the GitHub repository data using the Gemini model.
 
@@ -50,4 +48,4 @@ def get_gemini_summary(github_data: Dict[str, Any], model_temperature: float) ->
         json_response
     )  # Convert the returned json to markdown
 
-    return formatted_response
+    return {'formatted_response': formatted_response, 'usage': response.usage_metadata}

--- a/application/utils/callbacks.py
+++ b/application/utils/callbacks.py
@@ -35,6 +35,7 @@ def process_tasks(
     github_repository_url: str,
     output_file: Optional[Path],
     model_temperature: Optional[float],
+    token_usage: Optional[bool],
 ):
     """
     Processes the provided GitHub repository URL and performs tasks to analyze the repository.
@@ -80,7 +81,9 @@ def process_tasks(
         time.sleep(0.3)
 
         # Task 03 -> Generate the Gemini summary
-        repo_summary = get_gemini_summary(repo_data_json, model_temperature)
+        response = get_gemini_summary(repo_data_json, model_temperature)
+        usage = response['usage']
+        repo_summary = response['formatted_response']
         progress.advance(task)
         time.sleep(0.3)
         progress.update(task, completed=total_tasks)
@@ -103,3 +106,16 @@ def process_tasks(
             console.print(f"\n\n{completion_message}")
             md = Markdown(repo_summary)
             console.print(md)
+        
+        # If token_usage argument is specified, print the usage
+        if token_usage:
+            formatted_usage=("\n\033[92m"
+                "Token Usage:\n"
+                "-------------\n"
+                f"- Completion Tokens: {usage.candidates_token_count}\n"
+                f"- Prompt Tokens: {usage.prompt_token_count}\n"
+                f"- Total Tokens: {usage.total_token_count}\n"
+                "\033[0m")
+            err_console.print(f"\n[green]{formatted_usage}[/green]\n")
+        
+


### PR DESCRIPTION
### Description

This PR introduces a new `--token-usage` flag to the CLI, which allows users to output token usage information when interacting with the Gemini model. The changes are implemented in multiple files across the project to ensure that the flag is correctly handled, and the token usage statistics are printed to `stderr` if the flag is passed.

#### Changes made:
1. **_main.py**
   - Added the `--token-usage` flag using `typer.Option`. This flag is a boolean and defaults to `False`. When passed, it enables printing the token usage statistics.
   ```python
   token_usage: Annotated[
       bool, typer.Option("--token-usage", help="Flag for printing token usage")
   ] = False
   ```

2. **application/core/gemini_model.py**
   - Modified the `get_gemini_summary` function to return both the formatted summary of the GitHub repository and the token usage metadata. The return type was updated from `str` to `Dict[str, str]` to accommodate both the formatted response and usage metadata.
   
   Original function:
   ```python
   def get_gemini_summary(github_data: Dict[str, Any], model_temperature: float) -> str:
   #...
   return formatted_response
   ```

   Updated function:
   ```python
   def get_gemini_summary(github_data: Dict[str, Any], model_temperature: float) -> Dict[str, str]:
   #...
   return {'formatted_response': formatted_response, 'usage': response.usage_metadata}
   ```

3. **application/utils/callbacks.py**
   - Implemented logic to handle the `--token-usage` flag. If the flag is set, the token usage statistics (prompt tokens, completion tokens, and total tokens) are printed to `stderr` in a formatted, colored output.
   
   Added code:
   ```python
   if token_usage:
       formatted_usage = ("\n\033[92m"
                          "Token Usage:\n"
                          "-------------\n"
                          f"- Completion Tokens: {usage.candidates_token_count}\n"
                          f"- Prompt Tokens: {usage.prompt_token_count}\n"
                          f"- Total Tokens: {usage.total_token_count}\n"
                          "\033[0m")
       err_console.print(f"\n[green]{formatted_usage}[/green]\n")
   ```

### Reason for Changes

The addition of this flag provides greater transparency to users regarding the token usage when using the Gemini model. This can be helpful for optimizing token counts and understanding the underlying resource usage during model interactions.

- **Why `--token-usage`**: This flag allows users to explicitly request token statistics, avoiding clutter in standard output for users who do not need this information.
- **Design choice**: I chose to return the usage metadata as part of the existing `get_gemini_summary` function to keep the return structure compact and useful for multiple purposes.

### Challenges or Bugs

- **No bugs** encountered during testing.


This PR improves the usability of the Gemini model CLI and adds a useful feature for users who want to monitor token consumption during usage.