### PR TITLE
PR: Add Support for TOML "Dotfile" Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
   - [Arguments](#arguments)
   - [Options](#options)
   - [Status Codes](#status-codes)
+  - [TOML File Configuration](#toml-file-Configuration)
 - [More about `github-echo`](#more-about-github-echo)
   - [Information drawn from the GitHub API](#information-drawn-from-the-github-api)
   - [GenAI Integration](#genai-integration)
@@ -358,6 +359,50 @@ When executing the command, the tool returns the following status codes to indic
     - Problems with data retrieval or processing.
     - Missing API Keys.
     - Something wrong on the server side with any of the AI providers used.
+
+### TOML File Configuration
+
+`github-echo` supports a **TOML configuration file** that allows you to set default options for the tool, which are loaded from a `.github-echo-config.toml` file in your home directory. This feature simplifies repeated use by enabling persistent configurations without needing to specify them via command-line arguments every time.
+
+### How It Works
+
+1. The tool will automatically look for a `.github-echo-config.toml` file in your home directory.
+2. If the file is present, the tool will use the values specified there as default configurations.
+3. Command-line arguments always **override** any values specified in the TOML file, allowing for temporary changes as needed.
+
+### Creating the `.github-echo-config.toml` File
+
+To use this feature, create a `.github-echo-config.toml` file in your home directory with the following structure:
+
+```toml
+# Example .github-echo-config.toml
+
+# GitHub repository URL to analyze
+github_repository_url = "https://github.com/username/repository"
+
+# Select the model to use, either "gemini" or "groq"
+model = "gemini"
+
+# Model temperature setting, ranging from 0.0 (deterministic) to 2.0 (random)
+model_temperature = 0.5
+
+# Path to the output file for storing results
+output_file = "/path/to/output/results.md"
+
+# Flag to enable or disable token usage reporting
+token_usage = true
+```
+
+### Using the Configuration File
+
+- **Step 1**: Create the `.github-echo-config.toml` file in your home directory.
+  - On Linux/macOS: `~/`
+  - On Windows: `C:\Users\YourUsername\`
+- **Step 2**: Populate the file with your preferred default values.
+
+**Example File Path:**
+- Linux/macOS: `/home/username/.github-echo-config.toml`
+- Windows: `C:\Users\YourUsername\.github-echo-config.toml`
 
 ## More about `github-echo`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
   <strong>A command-line tool built to obtain in-depth, actionable information about GitHub repositories that is often challenging to decipher manually</strong><br /><br />
 </p>
 
-
 <p align="center">
   <a href="https://python.org">
     <img src="https://img.shields.io/badge/Python-3.11-blue?logo=python&logoColor=white" alt="Python Version">
@@ -54,6 +53,7 @@
   - [Arguments](#arguments)
   - [Options](#options)
   - [Status Codes](#status-codes)
+  - [TOML File Configuration](#toml-file-Configuration)
 - [More about `github-echo`](#more-about-github-echo)
   - [Information drawn from the GitHub API](#information-drawn-from-the-github-api)
   - [GenAI Integration](#genai-integration)
@@ -359,6 +359,50 @@ When executing the command, the tool returns the following status codes to indic
     - Problems with data retrieval or processing.
     - Missing API Keys.
     - Something wrong on the server side with any of the AI providers used.
+
+### TOML File Configuration
+
+`github-echo` supports a **TOML configuration file** that allows you to set default options for the tool, which are loaded from a `.github-echo-config.toml` file in your home directory. This feature simplifies repeated use by enabling persistent configurations without needing to specify them via command-line arguments every time.
+
+#### How It Works
+
+1. The tool will automatically look for a `.github-echo-config.toml` file in your home directory.
+2. If the file is present, the tool will use the values specified there as default configurations.
+3. Command-line arguments always **override** any values specified in the TOML file, allowing for temporary changes as needed.
+
+#### Creating the `.github-echo-config.toml` File
+
+To use this feature, create a `.github-echo-config.toml` file in your home directory with the following structure:
+
+```toml
+# Example .github-echo-config.toml
+
+# GitHub repository URL to analyze
+github_repository_url = "https://github.com/username/repository"
+
+# Select the model to use, either "gemini" or "groq"
+model = "gemini"
+
+# Model temperature setting, ranging from 0.0 (deterministic) to 2.0 (random)
+model_temperature = 0.5
+
+# Path to the output file for storing results
+output_file = "/path/to/output/results.md"
+
+# Flag to enable or disable token usage reporting
+token_usage = true
+```
+
+#### Using the Configuration File
+
+- **Step 1**: Create the `.github-echo-config.toml` file in your home directory.
+  - On Linux/macOS: `~/`
+  - On Windows: `C:\Users\YourUsername\`
+- **Step 2**: Populate the file with your preferred default values.
+
+**Example File Path:**
+- Linux/macOS: `/home/username/.github-echo-config.toml`
+- Windows: `C:\Users\YourUsername\.github-echo-config.toml`
 
 ## More about `github-echo`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
   - [Arguments](#arguments)
   - [Options](#options)
   - [Status Codes](#status-codes)
-  - [TOML File Configuration](#toml-file-Configuration)
+  - [TOML File Configuration](#toml-file-configuration)
 - [More about `github-echo`](#more-about-github-echo)
   - [Information drawn from the GitHub API](#information-drawn-from-the-github-api)
   - [GenAI Integration](#genai-integration)
@@ -401,6 +401,7 @@ token_usage = true
 - **Step 2**: Populate the file with your preferred default values.
 
 **Example File Path:**
+
 - Linux/macOS: `/home/username/.github-echo-config.toml`
 - Windows: `C:\Users\YourUsername\.github-echo-config.toml`
 

--- a/README.md
+++ b/README.md
@@ -364,13 +364,13 @@ When executing the command, the tool returns the following status codes to indic
 
 `github-echo` supports a **TOML configuration file** that allows you to set default options for the tool, which are loaded from a `.github-echo-config.toml` file in your home directory. This feature simplifies repeated use by enabling persistent configurations without needing to specify them via command-line arguments every time.
 
-### How It Works
+#### How It Works
 
 1. The tool will automatically look for a `.github-echo-config.toml` file in your home directory.
 2. If the file is present, the tool will use the values specified there as default configurations.
 3. Command-line arguments always **override** any values specified in the TOML file, allowing for temporary changes as needed.
 
-### Creating the `.github-echo-config.toml` File
+#### Creating the `.github-echo-config.toml` File
 
 To use this feature, create a `.github-echo-config.toml` file in your home directory with the following structure:
 
@@ -393,7 +393,7 @@ output_file = "/path/to/output/results.md"
 token_usage = true
 ```
 
-### Using the Configuration File
+#### Using the Configuration File
 
 - **Step 1**: Create the `.github-echo-config.toml` file in your home directory.
   - On Linux/macOS: `~/`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <strong>A command-line tool built to obtain in-depth, actionable information about GitHub repositories that is often challenging to decipher manually</strong><br /><br />
 </p>
 
+
 <p align="center">
   <a href="https://python.org">
     <img src="https://img.shields.io/badge/Python-3.11-blue?logo=python&logoColor=white" alt="Python Version">

--- a/_main.py
+++ b/_main.py
@@ -9,6 +9,8 @@ from rich.console import Console
 from typing_extensions import Annotated
 
 from application.utils.callbacks import process_tasks, version_callback
+from application.utils.parser import load_toml_config
+
 
 # Console instances for standard and error output
 console = Console(soft_wrap=True)
@@ -68,6 +70,22 @@ def github_repo_insights(
         version (Optional[bool]): Optional. If provided, prints the version number and exits the application.
         output_file (Optional[Path]): Optional. If provided, the path to a file where the Markdown summary will be saved.
     """
+    
+
+    # Load the TOML config from home directory
+    config = load_toml_config(".github-echo-config.toml")
+
+    if model == "gemini" and "model" in config:
+        model = config["model"]
+
+    if model_temperature == 0.5 and "model_temperature" in config:
+        model_temperature = config["model_temperature"]
+
+    if not output_file and "output_file" in config:
+        output_file = Path(config["output_file"])
+
+    if not token_usage and "token_usage" in config:
+        token_usage = config["token_usage"]
 
     try:
         asyncio.run(

--- a/_main.py
+++ b/_main.py
@@ -11,7 +11,6 @@ from typing_extensions import Annotated
 from application.utils.callbacks import process_tasks, version_callback
 from application.utils.parser import load_toml_config
 
-
 # Console instances for standard and error output
 console = Console(soft_wrap=True)
 err_console = Console(stderr=True, soft_wrap=True)
@@ -70,10 +69,15 @@ def github_repo_insights(
         version (Optional[bool]): Optional. If provided, prints the version number and exits the application.
         output_file (Optional[Path]): Optional. If provided, the path to a file where the Markdown summary will be saved.
     """
-    
 
     # Load the TOML config from home directory
     config = load_toml_config(".github-echo-config.toml")
+
+    if not config:
+        err_console.print(
+            ":warning: [bold yellow]Warning:[/] configuration file not found. Using default values.",
+            style="bold yellow",
+        )
 
     if model == "gemini" and "model" in config:
         model = config["model"]

--- a/application/utils/parser.py
+++ b/application/utils/parser.py
@@ -1,3 +1,36 @@
+# F.Khan Edited: 03-10-2024 
+import os
+import toml
+from pathlib import Path
+from typing import Dict
+
+def load_toml_config(file_name: str = ".github-echo-config.toml") -> Dict:
+    """
+    Load and parse the TOML config file from the user's home directory.
+
+    Args:
+        file_name (str): The name of the configuration file.
+
+    Returns:
+        dict: A dictionary with the configuration options.
+    """
+    home_dir = Path.home()  # Get the user's home directory
+    config_path = home_dir / file_name  # Construct the full path to the dotfile
+
+    if not config_path.exists():
+        # If the dotfile doesn't exist, return an empty dictionary
+        return {}
+
+    try:
+        # Trying to open and parse the TOML file
+        with open(config_path, 'r') as config_file:
+            return toml.load(config_file)
+    except toml.TomlDecodeError as e:
+        # If parsing the file fails, raise an error
+        raise RuntimeError(f"Failed to load or parse the config file: {str(e)}")
+
+
+
 def parse_github_url(github_repository_url: str) -> tuple[str, str]:
     """
     Parses a GitHub repository URL and extracts the username and repository name.

--- a/application/utils/parser.py
+++ b/application/utils/parser.py
@@ -1,5 +1,4 @@
 # F.Khan Edited: 03-10-2024 
-import os
 import toml
 from pathlib import Path
 from typing import Dict

--- a/application/utils/parser.py
+++ b/application/utils/parser.py
@@ -1,8 +1,9 @@
-# F.Khan Edited: 03-10-2024 
-import os
-import toml
+# F.Khan Edited: 03-10-2024
 from pathlib import Path
 from typing import Dict
+
+import toml
+
 
 def load_toml_config(file_name: str = ".github-echo-config.toml") -> Dict:
     """
@@ -23,12 +24,11 @@ def load_toml_config(file_name: str = ".github-echo-config.toml") -> Dict:
 
     try:
         # Trying to open and parse the TOML file
-        with open(config_path, 'r') as config_file:
+        with open(config_path, "r") as config_file:
             return toml.load(config_file)
     except toml.TomlDecodeError as e:
         # If parsing the file fails, raise an error
         raise RuntimeError(f"Failed to load or parse the config file: {str(e)}")
-
 
 
 def parse_github_url(github_repository_url: str) -> tuple[str, str]:

--- a/application/utils/parser.py
+++ b/application/utils/parser.py
@@ -2,8 +2,6 @@ import toml
 from pathlib import Path
 from typing import Dict
 
-import toml
-
 
 def load_toml_config(file_name: str = ".github-echo-config.toml") -> Dict:
     """

--- a/poetry.lock
+++ b/poetry.lock
@@ -957,6 +957,17 @@ files = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1046,4 +1057,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "494693b824a13da37588e430fea1d57002d0ba4e3553f57d8552fbf61de16e33"
+content-hash = "7f5c7dfede172ba8c0493e841b50f5cc30af9cd8811c0dd8bb2527eb89d505d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ httpx = "^0.27.2"
 pytest = "^8.3.3"
 single-source = "^0.4.0"
 groq = "^0.11.0"
+toml = "^0.10.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.6.4"


### PR DESCRIPTION
**Description:**
This PR adds support for users to specify configuration options via a TOML configuration file located in their home directory (e.g., `~/.github-echo-config.toml`). This feature allows users to persist their preferred options in a config file rather than providing them through command-line arguments every time.

**Key Features:**
- [x] The tool searches for a `.toml` config file in the user's home directory.
- [x] If the config file is missing, the tool will proceed as normal without any impact.
- [x] If the config file exists but cannot be parsed, the tool will exit and display an appropriate error message.
- [x] Values in the config file are used as defaults unless overridden by command-line arguments.
- [x] Unrecognized keys in the config file are ignored to allow flexibility in user configurations.
- [x] Further testing to ensure compatibility with all existing command-line arguments.
